### PR TITLE
Remove whitespace before php tag

### DIFF
--- a/quickbase.php
+++ b/quickbase.php
@@ -1,4 +1,4 @@
- <?php
+<?php
  /*----------------------------------------------------------------------
  Title : QuickBase PHP SDK
  Author : Joshua McGinnis (joshua_mcginnis@intuit.com)


### PR DESCRIPTION
Whitespace before the php tag can cause errors in any php file that includes quickbase.php and then attempts to use stdout. This is particularly noticeable when returning XML, for example, as it will result in whitespace before the XML declaration. Removing the whitespace before the php tag solves this issue.
