### PR TITLE
delete_record() full response

### DIFF
--- a/quickbase.php
+++ b/quickbase.php
@@ -451,7 +451,7 @@
 			$response = $this->transmit($url_string);
 		}
 		if($response) {
-			return true;
+			return $response;
 		}
 		return false;
 	}


### PR DESCRIPTION
Upated delete_record() to return the full response instead of just true/false. This allows for error handling.

P.D: May apply for other functions